### PR TITLE
Floating base

### DIFF
--- a/RBDReference.py
+++ b/RBDReference.py
@@ -193,7 +193,7 @@ class RBDReference:
         TODO Check the correct way to index the forces!
         """
         f_out = f_in
-        if len(f_ext > 0):
+        if len(f_ext) > 0:
             for curr_id in range(len(f_ext)):
                 parent_id = self.robot.get_parent_id(curr_id)
                 inds_q = self.robot.get_joint_index_q(curr_id)

--- a/RBDReference.py
+++ b/RBDReference.py
@@ -310,11 +310,10 @@ class RBDReference:
         f = np.zeros((6, NB))
         IC = np.zeros((NB,6,6))
         BC = np.zeros((NB,6,6))
-        S_ = {}
+        S_ = {} 
         Sd = {}
         Sdd = {}
         Sj = {}
-        # Xup0 = {}
         gravity_vec = np.zeros((6))
         gravity_vec[5] = -GRAVITY  # a_base is gravity vec
 
@@ -360,16 +359,7 @@ class RBDReference:
             IC[curr_id] = np.matmul(Xup0.T,np.matmul(Imat,Xup0))
             BC[curr_id] = 2 * self.factor_functions(IC[curr_id], v[:,curr_id])
             f[:, curr_id] = np.matmul(IC[curr_id], a[:, curr_id]) + self.vxIv(v[:, curr_id], IC[curr_id])
-        
-        print(f"NB: {NB}")
-        print(f"IC[0]:\n {IC[0].shape}\nIC[1]:\n{IC[1].shape}\n")
-        print(f"BC[0]:\n {BC[0].shape}\nBC[1]:\n{BC[1].shape}\n")
-        print(f"S_[0]:\n {S_[0].shape}\nS_[1]:\n{S_[1].shape}\n")
-        print(f"Sd[0]:\n {Sd[0].shape}\nSd[1]:\n{Sd[1].shape}\n")
-        print(f"Sdd[0]:\n {Sdd[0].shape}\nSdd[1]:\n{Sdd[1].shape}\n")
-        print(f"Sj[0]:\n {Sj[0].shape}\nSj[1]:\n{Sj[1].shape}\n")
-        print(f"Xup")
- 
+    
         return (f, IC, BC, S_, Sd, Sdd, Sj)
 
     def rnea_grad_bpass(self, f, IC, BC, S_, Sd, Sdd, Sj):

--- a/RBDReference.py
+++ b/RBDReference.py
@@ -412,20 +412,25 @@ class RBDReference:
             adj_subtreeInds = list(np.array(subtreeInds) + 5)
 
             if self.robot.floating_base and parent_id == -1:
+                # dc_dq calculation
                 dc_dq[ii,:] = np.matmul(S_[curr_id].T, tmp3[:,:])
                 dc_dq[:,ii] = (np.matmul(tmp1[:,:].T, Sdd[curr_id])  + np.matmul(tmp4[:,:].T,Sd[curr_id]))
-
+                
+                # dc_dqd calculation 
                 dc_dqd[ii,:] = np.matmul(S_[curr_id].T, tmp2[:,:])
                 dc_dqd[:,ii] = (np.matmul(tmp1[:,:].T, Sj[curr_id]) + np.matmul(tmp4[:,:].T,S_[curr_id]))
             else:
+                # dc_dq calculation 
                 dc_dq[ii,adj_subtreeInds] = np.matmul(S_[curr_id].T, tmp3[:,adj_subtreeInds])
                 dc_dq[adj_subtreeInds,ii] = np.squeeze(np.array((np.matmul(tmp1[:,adj_subtreeInds].T, Sdd[curr_id]) 
                                             + np.matmul(tmp4[:,adj_subtreeInds].T,Sd[curr_id]))))
                 
+                # dc_dqd calculation 
                 dc_dqd[ii,adj_subtreeInds] = np.matmul(S_[curr_id].T, tmp2[:,adj_subtreeInds])
                 dc_dqd[adj_subtreeInds,ii] = np.squeeze(np.array((np.matmul(tmp1[:,adj_subtreeInds].T, Sj[curr_id]) 
                                             + np.matmul(tmp4[:,adj_subtreeInds].T,S_[curr_id]))))
                 
+                # update forces 
                 IC[parent_id] += IC[curr_id]
                 BC[parent_id] += BC[curr_id]
                 f[:, parent_id] += f[:, curr_id]    


### PR DESCRIPTION
# Description

rnea_grad:
* Edited and fixed main branch implementation of ``rnea_grad`` to adjust for floating base.
* Added usage of ``inds_v = self.robot.get_joint_index_v(ind)`` in ``rnea_grad`` as well as throughout the entire branch which automatically accounts for floating base joint.
* Adjusted sizing of matrices in ``rnea_grad_fpass_dq`` and ``rnea_grad_fpass_dqd`` to have ``dv_dq, ``da_dq``, ``df_dq`` and the respective ``dqd`` versions to have initial memory allocation ``np.zeros((6,n,NB))`` where ``n`` is the length of vector ``qd`` and ``NB = self.robot.get_num_bodies()``. 
* Accordingly adjusted variable accessing according to previous bullet.
* There remains nested for loops in each fpass function that may compress to one step, but it requires extra math.

crm, crf, icrf, factor_functions: 
* Added helper functions for rnea_grad. 
* ``cross_operator`` (crm in spatial v2) computes for any vector v the operator v x (v cross)
* ``dual_cross_operator`` (crf in spatial v2) computes spatial/planar cross product operator force. Essentially calls ``-self.crm(v).T``
* ``icrf`` implemented in main branch and used in rnea_grad. Helper function defined in spatial_v2 extended library and called by ``idsva`` (main branch) and ``rnea_grad``
* ``factor_functions`` is a helper function defined in spatial_v2 extended library for use in ``rnea_grad()`` and ``idsva()``.

apply_external_forces:
* Added implementation based on spatial v2 linked above.
* Function subtracts external forces from parameter input ``f_in``.

ABA:
* Fixed minor implementation issues and adjusted some variable names.
* Added docstrings for ease of reading.
* Potential rounding errors causing significantly small results (see last commit), otherwise implementation is correct
* For further work, see calculation of ``qdd`` in order to dissect location of rounding errors (``u[inds_v]`` line 731 and ``U[:, inds_v]`` lines 729 and 732).

# Tests

Ran in terminal from forked repo here at base of working directory:
https://github.com/kawotwi/GRiD/tree/floating-base
***NOTE: You may need to edit import statements to reflect directory structure.

**iiwa14.urdf testing**
* ``python printReferenceValues.py iiwa.urdf -f``
* ``python printReferenceValues.py iiwa.urdf``

**hyq.urdf testing**

* ``python printReferenceValues.py hyq.urdf -f``
* ``python printReferenceValues.py hyq.urdf``

**Benchmark testing against Matlab values using the following sequence:** (These instructions are in the previous pull request here: https://github.com/A2R-Lab/RBDReference/pull/5) 

* Run python compare_rnea_fb_spatial.py INSERT_URDF.urdf -f which will print the exact q, qd, qdd necessary for any spatial floating base algorithms to account for floating base joint inserted at the next step. Essentially what this file is doing is creating a format compatible with Matlab. Matlab for floating base joints expects the quaternion (xyzw for spatial_v2) and xyz location of the floating base joint, then a separate list for the joint angles sized appropriately for the respective urdf.
* Generate floating base URDF for Matlab testing in terminal at base of working directory of GRiD using python generate_spatial_model.py INSERT_URDF.urdf -f to generate INSERT_URDF.m file. This effectively adds a floating base joint at the base of the URDF for Matlab.
* Place the newly generated urdf.m file in working directory of spatial_v2_extended
* Run the addPath function in Matlab commented at the top of the matlab_dynamics_test_script.m to make sure directories are sourced correctly.
* Within the test script, paste the exact outputs from q, qd, qdd from the first step with brackets as inputs to the dynamics functions.
* Run matlab_dynamics_test_script.m to familiarize yourself and see input structure. It will output floating base tau from RNEA, H (output of CRBA joint space inertia matrix), and Hinv (analytical inverse of joint space inertia matrix)
* To test rnea_grad do the following: ``[dtau_dq, dtau_dqd] = ID_derivatives( fb_model, q_fb, qd_fb, qdd_fb )``
* To test ABA do the following: ``qdd = FDab( fb_model, q_fb, qd_fb, tau_fb, ext_array)`` and use the according tau from GRiD output. 

